### PR TITLE
chore(entrega06): implantação com Kubernetes 

### DIFF
--- a/Back-End/barramento-de-eventos/index.js
+++ b/Back-End/barramento-de-eventos/index.js
@@ -7,9 +7,9 @@ app.use(express.json())
 app.post('/eventos', (req, res) => {
     const evento = req.body
     //envia o evento para o microsserviço de cavalos
-    axios.post('http://192.168.56.1:4000/eventos', evento)
+    axios.post('http://cavalos-clusterip-service:4000/eventos', evento)
     //envia o evento para o microsserviço de proprietários
-    axios.post('http://192.168.56.1:5000/eventos', evento)
+    axios.post('http://proprietarios.clusterip-service:5000/eventos', evento)
     res.status(200).send({msg: 'ok'})
 })
 

--- a/Back-End/barramento-de-eventos/index.js
+++ b/Back-End/barramento-de-eventos/index.js
@@ -9,7 +9,7 @@ app.post('/eventos', (req, res) => {
     //envia o evento para o microsserviço de cavalos
     axios.post('http://cavalos-clusterip-service:4000/eventos', evento)
     //envia o evento para o microsserviço de proprietários
-    axios.post('http://proprietarios.clusterip-service:5000/eventos', evento)
+    axios.post('http://proprietarios-clusterip-service:5000/eventos', evento)
     res.status(200).send({msg: 'ok'})
 })
 

--- a/Back-End/cavalos/index.js
+++ b/Back-End/cavalos/index.js
@@ -39,7 +39,7 @@ app.post('/cavalos', async (req, res) => {
         idCavalo, infos
     }
 
-    await axios.post("http://192.168.56.1:50000/eventos", {
+    await axios.post("http://barramento-de-eventos-service:50000/eventos", {
         tipo: 'CavaloCriado',
         dados: {
             idCavalo, 

--- a/Back-End/implantacao/kubernetes/barramento-de-eventos-deploy.yaml
+++ b/Back-End/implantacao/kubernetes/barramento-de-eventos-deploy.yaml
@@ -17,13 +17,24 @@ spec:
       labels:
         # Pods terão esse rótulo, sendo selecionados por esse deployment
         app: barramento-de-eventos
-      
+ 
     spec:
       containers:
       - name: barramento-de-eventos
         image: iz120/barramento-de-eventos
-        imagePullPolicy: Never
-        resources:
-          limits:
-            memory: 256Mi
-            cpu: 1
+        
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: barramento-de-eventos-service
+spec:
+  selector:
+    app: barramento-de-eventos
+  # IP interno do Cluster
+  type: ClusterIP
+  ports:
+  - name: barramento-de-eventos
+    protocol: TCP
+    port: 50000
+    targetPort: 50000

--- a/Back-End/implantacao/kubernetes/barramento-de-eventos-deploy.yaml
+++ b/Back-End/implantacao/kubernetes/barramento-de-eventos-deploy.yaml
@@ -21,7 +21,8 @@ spec:
     spec:
       containers:
       - name: barramento-de-eventos
-        image: iz120/barramento-de-eventos:0.0
+        image: iz120/barramento-de-eventos
+        imagePullPolicy: Never
         resources:
           limits:
             memory: 256Mi

--- a/Back-End/implantacao/kubernetes/barramento-de-eventos-deploy.yaml
+++ b/Back-End/implantacao/kubernetes/barramento-de-eventos-deploy.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+# Nome do Deployment
+  name: barramento-de-eventos-deploy
+spec:
+  # Número de cópias
+  replicas: 1
+  # Especificar o rótulo
+  selector:
+    matchLabels:
+      # Deployment vai selecionar todo Pod com esse rótulo
+      app: barramento-de-eventos
+  # Modelo que vai ser usado para construir os Pods
+  template:
+    metadata:
+      labels:
+        # Pods terão esse rótulo, sendo selecionados por esse deployment
+        app: barramento-de-eventos
+      
+    spec:
+      containers:
+      - name: barramento-de-eventos
+        image: iz120/barramento-de-eventos:0.0
+        resources:
+          limits:
+            memory: 256Mi
+            cpu: 1

--- a/Back-End/implantacao/kubernetes/cavalos-deploy.yaml
+++ b/Back-End/implantacao/kubernetes/cavalos-deploy.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+# Nome do Deployment
+  name: cavalos-deploy
+spec:
+  # Número de cópias
+  replicas: 1
+  # Especificar o rótulo
+  selector:
+    matchLabels:
+      # Deployment vai selecionar todo Pod com esse rótulo
+      app: cavalos
+  # Modelo que vai ser usado para construir os Pods
+  template:
+    metadata:
+      labels:
+        # Pods terão esse rótulo, sendo selecionados por esse deployment
+        app: cavalos
+      
+    spec:
+      containers:
+      - name: cavalos
+        image: iz120/cavalos:0.0
+        resources:
+          limits:
+            memory: 256Mi
+            cpu: 1

--- a/Back-End/implantacao/kubernetes/cavalos-deploy.yaml
+++ b/Back-End/implantacao/kubernetes/cavalos-deploy.yaml
@@ -21,7 +21,8 @@ spec:
     spec:
       containers:
       - name: cavalos
-        image: iz120/cavalos:0.0
+        image: iz120/cavalos
+        imagePullPolicy: Never
         resources:
           limits:
             memory: 256Mi

--- a/Back-End/implantacao/kubernetes/cavalos-deploy.yaml
+++ b/Back-End/implantacao/kubernetes/cavalos-deploy.yaml
@@ -39,6 +39,6 @@ spec:
     app: cavalos
   ports:
   - name: cavalos
-  protocol: TCP
-  port: 4000
-  taregtPort: 4000
+    protocol: TCP
+    port: 4000
+    targetPort: 4000

--- a/Back-End/implantacao/kubernetes/cavalos-deploy.yaml
+++ b/Back-End/implantacao/kubernetes/cavalos-deploy.yaml
@@ -27,3 +27,18 @@ spec:
           limits:
             memory: 256Mi
             cpu: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # Nome diferente do serviço tipo NodePort
+  name: cavalos-clusterip-service
+spec:
+  selector:
+    app: cavalos
+  ports:
+  - name: cavalos
+  protocol: TCP
+  port: 4000
+  taregtPort: 4000

--- a/Back-End/implantacao/kubernetes/cavalos-service.yaml
+++ b/Back-End/implantacao/kubernetes/cavalos-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cavalos-service
+spec:
+  # IP externo, acessível fora do Cluster
+  type: NodePort
+  selector:
+    # Todo Pod com essa tag fará parte deste serviço
+    app: cavalos
+  ports:
+  - name: cavalos
+    protocol: TCP
+    # Porta na qual o nó recebe requisições
+    port: 4000
+    # Porta para a qual o nó redireciona a requisição
+    targetPort: 4000

--- a/Back-End/implantacao/kubernetes/proprietarios-deploy.yaml
+++ b/Back-End/implantacao/kubernetes/proprietarios-deploy.yaml
@@ -21,7 +21,8 @@ spec:
     spec:
       containers:
       - name: proprietarios
-        image: iz120/proprietarios:0.0
+        image: iz120/proprietarios
+        imagePullPolicy: Never
         resources:
           limits:
             memory: 256Mi

--- a/Back-End/implantacao/kubernetes/proprietarios-deploy.yaml
+++ b/Back-End/implantacao/kubernetes/proprietarios-deploy.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+# Nome do Deployment
+  name: proprietarios-deploy
+spec:
+  # Número de cópias
+  replicas: 1
+  # Especificar o rótulo
+  selector:
+    matchLabels:
+      # Deployment vai selecionar todo Pod com esse rótulo
+      app: proprietarios
+  # Modelo que vai ser usado para construir os Pods
+  template:
+    metadata:
+      labels:
+        # Pods terão esse rótulo, sendo selecionados por esse deployment
+        app: proprietarios
+      
+    spec:
+      containers:
+      - name: proprietarios
+        image: iz120/proprietarios:0.0
+        resources:
+          limits:
+            memory: 256Mi
+            cpu: 1

--- a/Back-End/implantacao/kubernetes/proprietarios-deploy.yaml
+++ b/Back-End/implantacao/kubernetes/proprietarios-deploy.yaml
@@ -27,3 +27,18 @@ spec:
           limits:
             memory: 256Mi
             cpu: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # Nome diferente do serviço tipo NodePort
+  name: proprietarios-clusterip-service
+spec:
+  selector:
+    app: proprietarios
+  ports:
+  - name: proprietarios
+  protocol: TCP
+  port: 5000
+  taregtPort: 5000

--- a/Back-End/implantacao/kubernetes/proprietarios-deploy.yaml
+++ b/Back-End/implantacao/kubernetes/proprietarios-deploy.yaml
@@ -39,6 +39,6 @@ spec:
     app: proprietarios
   ports:
   - name: proprietarios
-  protocol: TCP
-  port: 5000
-  taregtPort: 5000
+    protocol: TCP
+    port: 5000
+    targetPort: 5000

--- a/Back-End/implantacao/kubernetes/proprietarios-service.yaml
+++ b/Back-End/implantacao/kubernetes/proprietarios-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: proprietarios-service
+spec:
+  # IP externo, acessível fora do Cluster
+  type: NodePort
+  selector:
+    # Todo Pod com essa tag fará parte deste serviço
+    app: proprietarios
+  ports:
+  - name: proprietarios
+    protocol: TCP
+    # Porta na qual o nó recebe requisições
+    port: 5000
+    # Porta para a qual o nó redireciona a requisição
+    targetPort: 5000

--- a/Back-End/proprietarios/index.js
+++ b/Back-End/proprietarios/index.js
@@ -21,7 +21,7 @@ app.post('/proprietarios', async (req, res) => {
     }
     console.log('Criou o proprietário')
 
-    await axios.post("http://192.168.56.1:50000/eventos", {
+    await axios.post("http://barramento-de-eventos-service:50000/eventos", {
         tipo: 'ProprietarioCriado',
         dados: {
             idProprietario,


### PR DESCRIPTION
feat(back-end): implementa a utilização do Docker para executar os micro serviços

Este PR possibilita o gerenciamento dos contêiners Docker através do Kubernetes. Agora, as portas das requisições dependem das portas dor serviços (services).

**Próximos Passos:**

- Testar através do front-end.